### PR TITLE
Add CF_RUN_SUBDOMAIN and CF_APPS_SUBDOMAIN variables to make CF_DOMAIN prefixing configurable/optional (defaults remain the same)

### DIFF
--- a/aws-cf-install.tf
+++ b/aws-cf-install.tf
@@ -96,12 +96,12 @@ output "cf_domain" {
   value = "${var.cf_domain}"
 }
 
-output "run_subdomain" {
-  value = "${var.run_subdomain}"
+output "cf_run_subdomain" {
+  value = "${var.cf_run_subdomain}"
 }
 
-output "apps_subdomain" {
-  value = "${var.apps_subdomain}"
+output "cf_apps_subdomain" {
+  value = "${var.cf_apps_subdomain}"
 }
 
 resource "aws_security_group_rule" "nat" {

--- a/aws-cf-install.tf
+++ b/aws-cf-install.tf
@@ -96,6 +96,14 @@ output "cf_domain" {
   value = "${var.cf_domain}"
 }
 
+output "run_subdomain" {
+  value = "${var.run_subdomain}"
+}
+
+output "apps_subdomain" {
+  value = "${var.apps_subdomain}"
+}
+
 resource "aws_security_group_rule" "nat" {
 	source_security_group_id = "${module.cf-net.aws_security_group_cf_id}"
 
@@ -204,6 +212,7 @@ output "runner_z2_count"   { value = "${lookup(var.runner_z2_count,   var.deploy
 output "private_cf_domains" {
 	value = "${var.private_cf_domains}"
 }
+
 output "additional_cf_sg_allows" {
   value = "${var.additional_cf_sg_allow_1},${var.additional_cf_sg_allow_2},${var.additional_cf_sg_allow_3},${var.additional_cf_sg_allow_4},${var.additional_cf_sg_allow_5},${module.cf-net.aws_cf_a_cidr},${module.cf-net.aws_cf_b_cidr},${module.cf-net.aws_lb_cidr},${module.cf-net.aws_docker_cidr},${module.cf-net.aws_eip_cf_public_ip}"
 }

--- a/provision.sh
+++ b/provision.sh
@@ -36,8 +36,8 @@ CF_RELEASE_VERSION=${22}
 DEBUG=${23}
 PRIVATE_DOMAINS=${24}
 CF_SG_ALLOWS=${25}
-RUN_SUBDOMAIN=${26}
-APPS_SUBDOMAIN=${27}
+CF_RUN_SUBDOMAIN=${26}
+CF_APPS_SUBDOMAIN=${27}
 
 BACKBONE_Z1_COUNT=COUNT
 API_Z1_COUNT=COUNT
@@ -248,18 +248,18 @@ if [[ ! -f "/usr/local/bin/spiff" ]]; then
   rm spiff_linux_amd64.zip
 fi
 
-# If RUN_SUBDOMAIN is set, then use it's value to replace the default subdomain. Otherwise (if empty), don't use a subdomain
-if [[ -n "$RUN_SUBDOMAIN" ]]; then
-  RUN_SUBDOMAIN_SED_EXPRESSION="s/run.CF_DOMAIN/${RUN_SUBDOMAIN}.${CF_DOMAIN}/g"
+# If CF_RUN_SUBDOMAIN is set, then use it's value to replace the default subdomain. Otherwise (if empty), don't use a subdomain
+if [[ -n "$CF_RUN_SUBDOMAIN" ]]; then
+  CF_RUN_SUBDOMAIN_SED_EXPRESSION="s/run.CF_DOMAIN/${CF_RUN_SUBDOMAIN}.${CF_DOMAIN}/g"
 else
-  RUN_SUBDOMAIN_SED_EXPRESSION="s/run.CF_DOMAIN/${CF_DOMAIN}/g"
+  CF_RUN_SUBDOMAIN_SED_EXPRESSION="s/run.CF_DOMAIN/${CF_DOMAIN}/g"
 fi
 
-# If APPS_SUBDOMAIN is set, then use it's value to replace the default subdomain. Otherwise (if empty), don't use a subdomain
-if [[ -n "$APPS_SUBDOMAIN" ]]; then
-  APPS_SUBDOMAIN_SED_EXPRESSION="s/apps.CF_DOMAIN/${APPS_SUBDOMAIN}.${CF_DOMAIN}/g"
+# If CF_APPS_SUBDOMAIN is set, then use it's value to replace the default subdomain. Otherwise (if empty), don't use a subdomain
+if [[ -n "$CF_APPS_SUBDOMAIN" ]]; then
+  CF_APPS_SUBDOMAIN_SED_EXPRESSION="s/apps.CF_DOMAIN/${CF_APPS_SUBDOMAIN}.${CF_DOMAIN}/g"
 else
-  APPS_SUBDOMAIN_SED_EXPRESSION="s/apps.CF_DOMAIN/${CF_DOMAIN}/g"
+  CF_APPS_SUBDOMAIN_SED_EXPRESSION="s/apps.CF_DOMAIN/${CF_DOMAIN}/g"
 fi
 
 # This is some hackwork to get the configs right. Could be changed in the future
@@ -272,8 +272,8 @@ fi
   -e "s/CF_SUBNET2/${CF_SUBNET2}/g" \
   -e "s/LB_SUBNET1/${LB_SUBNET1}/g" \
   -e "s/DIRECTOR_UUID/${DIRECTOR_UUID}/g" \
-  -e $RUN_SUBDOMAIN_SED_EXPRESSION \
-  -e $APPS_SUBDOMAIN_SED_EXPRESSION \
+  -e $CF_RUN_SUBDOMAIN_SED_EXPRESSION \
+  -e $CF_APPS_SUBDOMAIN_SED_EXPRESSION \
   -e "s/CF_DOMAIN/${CF_DOMAIN}/g" \
   -e "s/CF_ADMIN_PASS/${CF_ADMIN_PASS}/g" \
   -e "s/IPMASK/${IPMASK}/g" \

--- a/provision.sh
+++ b/provision.sh
@@ -36,6 +36,8 @@ CF_RELEASE_VERSION=${22}
 DEBUG=${23}
 PRIVATE_DOMAINS=${24}
 CF_SG_ALLOWS=${25}
+RUN_SUBDOMAIN=${26}
+APPS_SUBDOMAIN=${27}
 
 BACKBONE_Z1_COUNT=COUNT
 API_Z1_COUNT=COUNT
@@ -246,6 +248,20 @@ if [[ ! -f "/usr/local/bin/spiff" ]]; then
   rm spiff_linux_amd64.zip
 fi
 
+# If RUN_SUBDOMAIN is set, then use it's value to replace the default subdomain. Otherwise (if empty), don't use a subdomain
+if [[ -n "$RUN_SUBDOMAIN" ]]; then
+  RUN_SUBDOMAIN_SED_EXPRESSION="s/run.CF_DOMAIN/${RUN_SUBDOMAIN}.${CF_DOMAIN}/g"
+else
+  RUN_SUBDOMAIN_SED_EXPRESSION="s/run.CF_DOMAIN/${CF_DOMAIN}/g"
+fi
+
+# If APPS_SUBDOMAIN is set, then use it's value to replace the default subdomain. Otherwise (if empty), don't use a subdomain
+if [[ -n "$APPS_SUBDOMAIN" ]]; then
+  APPS_SUBDOMAIN_SED_EXPRESSION="s/apps.CF_DOMAIN/${APPS_SUBDOMAIN}.${CF_DOMAIN}/g"
+else
+  APPS_SUBDOMAIN_SED_EXPRESSION="s/apps.CF_DOMAIN/${CF_DOMAIN}/g"
+fi
+
 # This is some hackwork to get the configs right. Could be changed in the future
 /bin/sed -i \
   -e "s/CF_SUBNET1_AZ/${CF_SUBNET1_AZ}/g" \
@@ -256,6 +272,8 @@ fi
   -e "s/CF_SUBNET2/${CF_SUBNET2}/g" \
   -e "s/LB_SUBNET1/${LB_SUBNET1}/g" \
   -e "s/DIRECTOR_UUID/${DIRECTOR_UUID}/g" \
+  -e $RUN_SUBDOMAIN_SED_EXPRESSION \
+  -e $APPS_SUBDOMAIN_SED_EXPRESSION \
   -e "s/CF_DOMAIN/${CF_DOMAIN}/g" \
   -e "s/CF_ADMIN_PASS/${CF_ADMIN_PASS}/g" \
   -e "s/IPMASK/${IPMASK}/g" \

--- a/provision/prepare-provision
+++ b/provision/prepare-provision
@@ -59,8 +59,8 @@ assure_string_in_file $filename_provision 'CF_RELEASE_VERSION=${22}' "CF_RELEASE
 assure_string_in_file $filename_provision 'DEBUG=${23}' "DEBUG=\"$(terraform output -state="${state_file}" debug)\""
 assure_string_in_file $filename_provision 'PRIVATE_DOMAINS=${24}' "PRIVATE_DOMAINS=\"$(terraform output -state="${state_file}" private_cf_domains)\""
 assure_string_in_file $filename_provision 'CF_SG_ALLOWS=${25}' "CF_SG_ALLOWS=\"$(terraform output -state="${state_file}" additional_cf_sg_allows)\""
-assure_string_in_file $filename_provision 'RUN_SUBDOMAIN=${26}' "RUN_SUBDOMAIN=\"$(terraform output -state="${state_file}" run_subdomain)\""
-assure_string_in_file $filename_provision 'APPS_SUBDOMAIN=${27}' "APPS_SUBDOMAIN=\"$(terraform output -state="${state_file}" apps_subdomain)\""
+assure_string_in_file $filename_provision 'CF_RUN_SUBDOMAIN=${26}' "CF_RUN_SUBDOMAIN=\"$(terraform output -state="${state_file}" cf_run_subdomain)\""
+assure_string_in_file $filename_provision 'CF_APPS_SUBDOMAIN=${27}' "CF_APPS_SUBDOMAIN=\"$(terraform output -state="${state_file}" cf_apps_subdomain)\""
 
 for job in BACKBONE API SERVICES HEALTH RUNNER; do
 	for zone in Z1 Z2; do

--- a/provision/prepare-provision
+++ b/provision/prepare-provision
@@ -59,6 +59,8 @@ assure_string_in_file $filename_provision 'CF_RELEASE_VERSION=${22}' "CF_RELEASE
 assure_string_in_file $filename_provision 'DEBUG=${23}' "DEBUG=\"$(terraform output -state="${state_file}" debug)\""
 assure_string_in_file $filename_provision 'PRIVATE_DOMAINS=${24}' "PRIVATE_DOMAINS=\"$(terraform output -state="${state_file}" private_cf_domains)\""
 assure_string_in_file $filename_provision 'CF_SG_ALLOWS=${25}' "CF_SG_ALLOWS=\"$(terraform output -state="${state_file}" additional_cf_sg_allows)\""
+assure_string_in_file $filename_provision 'RUN_SUBDOMAIN=${26}' "RUN_SUBDOMAIN=\"$(terraform output -state="${state_file}" run_subdomain)\""
+assure_string_in_file $filename_provision 'APPS_SUBDOMAIN=${27}' "APPS_SUBDOMAIN=\"$(terraform output -state="${state_file}" apps_subdomain)\""
 
 for job in BACKBONE API SERVICES HEALTH RUNNER; do
 	for zone in Z1 Z2; do

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,14 @@ variable "cf_domain" {
   default = "XIP"
 }
 
+variable "run_subdomain" {
+  default = "run"
+}
+
+variable "apps_subdomain" {
+  default = "apps"
+}
+
 variable "cf_boshworkspace_version" {
   default = "v1.1.15"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,11 +51,11 @@ variable "cf_domain" {
   default = "XIP"
 }
 
-variable "run_subdomain" {
+variable "cf_run_subdomain" {
   default = "run"
 }
 
-variable "apps_subdomain" {
+variable "cf_apps_subdomain" {
   default = "apps"
 }
 


### PR DESCRIPTION
In [cloudfoundry-community/cf-boshworkspace](https://github.com/cloudfoundry-community/cf-boshworkspace) the templates assume that you want to use ```run.CF_DOMAIN``` and ```apps.CF_DOMAIN``` while users might want to change that to a different prefix or no prefix at all (run everything on the same (wildcard) domain to support wildcard SSL certificates out of the box.
These changes make the ```CF_RUN_SUBDOMAIN``` and ```CF_APPS_SUBDOMAIN``` configurable with the following options:

1. default remains the same, so if the user doesn't want to change anything, the output template would be exactly the same
2. if the user sets ```cf_run_subdomain``` and ```cf_apps_subdomain``` to custom values in it's ```terraform.tfvars```, the output template would use those custom values for ```meta.domain``` and ```meta.app_domains```
3. if the user sets ```cf_run_subdomain``` and ```cf_apps_subdomain``` to blank values in it's ```terraform.tfvars```, the output template would use no subdomain prefix (so just ```CF_DOMAIN```) for ```meta.domain``` and ```meta.app_domains```